### PR TITLE
Reduce params being sent to psycopg

### DIFF
--- a/djsonb/lookups.py
+++ b/djsonb/lookups.py
@@ -166,9 +166,9 @@ def intrange_filter(path, range_rule):
     if not has_min and not has_max:
         return ('', [])
     if has_min and not has_max:
-        return ('(' + more_than + ')', path + [minimum])
+        return ('(' + more_than + ')', path[1:] + [minimum])
     elif has_max and not has_min:
-        return ('(' + less_than + ')', path + [maximum])
+        return ('(' + less_than + ')', path[1:] + [maximum])
     elif has_max and has_min:
         min_and_max = '(' + less_than + ' AND ' + more_than + ')'
         return (min_and_max, path[1:] + [maximum] + path[1:] + [minimum])

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ PostgreSQL json field support for Django.
 
 setup(
     name="djsonb",
-    version="0.1.2",
+    version="0.1.3",
     url="https://github.com/azavea/djsonb",
     license="BSD",
     platforms=["OS Independent"],

--- a/tests/djsonb_fields/tests.py
+++ b/tests/djsonb_fields/tests.py
@@ -144,9 +144,9 @@ class JsonBFilterTests(TestCase):
         self.assertEqual(intrange_filter(['a', 'b', 'c'], {'_rule_type': 'intrange', 'min': None}),
                          ('', []))
         self.assertEqual(intrange_filter(['a', 'b', 'c'], {'_rule_type': 'intrange', 'min': 1}),
-                         (u'((a->%s->>%s)::int >= %s)', [u'a', u'b', u'c', 1]))
+                         (u'((a->%s->>%s)::int >= %s)', [u'b', u'c', 1]))
         self.assertEqual(intrange_filter(['a', 'b', 'c'], {'_rule_type': 'intrange', 'max': 1}),
-                         (u'((a->%s->>%s)::int <= %s)', [u'a', u'b', u'c', 1]))
+                         (u'((a->%s->>%s)::int <= %s)', [u'b', u'c', 1]))
         self.assertEqual(intrange_filter(['a', 'b', 'c'], {'_rule_type': 'intrange', 'max': 1, 'min': None}),
-                         (u'((a->%s->>%s)::int <= %s)', [u'a', u'b', u'c', 1]))
+                         (u'((a->%s->>%s)::int <= %s)', [u'b', u'c', 1]))
 


### PR DESCRIPTION
Too many parameters were being supplied in cases where min or max were not set - this should rectify that bug.
