### PR TITLE
Feature/exclude null filters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ PostgreSQL json field support for Django.
 
 setup(
     name="djsonb",
-    version="0.1.3",
+    version="0.1.4",
     url="https://github.com/azavea/djsonb",
     license="BSD",
     platforms=["OS Independent"],

--- a/tests/djsonb_fields/tests.py
+++ b/tests/djsonb_fields/tests.py
@@ -6,9 +6,8 @@ from django.test import TestCase
 from .models import JsonBModel
 
 from djsonb.lookups import (FilterTree,
-                            traversal_string,
-                            containment_filter,
-                            intrange_filter)
+                            traversal_string,)
+
 
 class JsonBFilterTests(TestCase):
     def setUp(self):
@@ -51,10 +50,9 @@ class JsonBFilterTests(TestCase):
                           ('{"a": {"b": {"c": "test1"}}}', '{"a": {"b": {"c": "a thing"}}}')))
 
     def test_containment_output(self):
-        self.assertEqual(containment_filter(['a', 'b'], self.mock_contains_rule),
+        self.assertEqual(FilterTree.containment_filter(['a', 'b'], self.mock_contains_rule),
                          ('(a @> %s OR a @> %s)',
                           ['{"b": "test1"}', '{"b": "a thing"}']))
-
 
     def test_containment_query(self):
         JsonBModel.objects.create(data={'a': {'b': {'c': 1}}})
@@ -141,12 +139,24 @@ class JsonBFilterTests(TestCase):
 
     def test_intrange_filter_missing_numbers(self):
         """Test to ensure that missing min and max doesn't add filters"""
-        self.assertEqual(intrange_filter(['a', 'b', 'c'], {'_rule_type': 'intrange', 'min': None}),
-                         ('', []))
-        self.assertEqual(intrange_filter(['a', 'b', 'c'], {'_rule_type': 'intrange', 'min': 1}),
+        self.assertEqual(FilterTree.intrange_filter(['a', 'b', 'c'],
+                         {'_rule_type': 'intrange', 'min': None}),
+                         None)
+        self.assertEqual(FilterTree.intrange_filter(['a', 'b', 'c'],
+                         {'_rule_type': 'intrange', 'min': 1}),
                          (u'((a->%s->>%s)::int >= %s)', [u'b', u'c', 1]))
-        self.assertEqual(intrange_filter(['a', 'b', 'c'], {'_rule_type': 'intrange', 'max': 1}),
+        self.assertEqual(FilterTree.intrange_filter(['a', 'b', 'c'],
+                         {'_rule_type': 'intrange', 'max': 1}),
                          (u'((a->%s->>%s)::int <= %s)', [u'b', u'c', 1]))
-        self.assertEqual(intrange_filter(['a', 'b', 'c'], {'_rule_type': 'intrange', 'max': 1, 'min': None}),
+        self.assertEqual(FilterTree.intrange_filter(['a', 'b', 'c'],
+                         {'_rule_type': 'intrange', 'max': 1, 'min': None}),
                          (u'((a->%s->>%s)::int <= %s)', [u'b', u'c', 1]))
 
+    def test_exclude_null_filters(self):
+        """Test that filters which return None are excluded from the query string"""
+        int_none_rule = {'_rule_type': 'intrange', 'min': None, 'max': None}
+        other_rule = self.mock_contains_rule
+        jsonb_query = {'should_be': other_rule, 'should_not_be': int_none_rule}
+        ft = FilterTree(jsonb_query, 'data')
+        sql_str, sql_params = ft.sql()
+        self.assertFalse('AND' in sql_str, 'Found "AND" in query string')  # Should only be one rule.

--- a/tests/djsonb_fields/tests.py
+++ b/tests/djsonb_fields/tests.py
@@ -6,7 +6,8 @@ from django.test import TestCase
 from .models import JsonBModel
 
 from djsonb.lookups import (FilterTree,
-                            traversal_string,)
+                            extract_value_at_path,
+                            contains_key_at_path)
 
 
 class JsonBFilterTests(TestCase):
@@ -26,8 +27,11 @@ class JsonBFilterTests(TestCase):
         self.distraction = {'alpha': {'beta': {'gamma': {'delta': self.mock_int_rule}, 'distraction': []}}}
         self.distraction_tree = FilterTree(self.distraction, 'data')
 
-    def test_traversal_string_creation(self):
-        self.assertEqual(traversal_string(['a', 'b', 'c']), u"a->%s->>%s")
+    def test_value_extraction_generation(self):
+        self.assertEqual(extract_value_at_path(['a', 'b', 'c']), u"a->%s->>%s")
+
+    def test_key_containment_generation(self):
+        self.assertEqual(contains_key_at_path(['a', 'b', 'c']), u"a->%s?%s")
 
     def test_intrange_rules(self):
         self.assertEqual(self.two_rule_tree.rules, [(['data', 'testing'], self.mock_int_rule)])
@@ -144,13 +148,16 @@ class JsonBFilterTests(TestCase):
                          None)
         self.assertEqual(FilterTree.intrange_filter(['a', 'b', 'c'],
                          {'_rule_type': 'intrange', 'min': 1}),
-                         (u'((a->%s->>%s)::int >= %s)', [u'b', u'c', 1]))
+                         (u'((a->%s->>%s)::int >= %s)',
+                          [u'b', u'c', 1]))
         self.assertEqual(FilterTree.intrange_filter(['a', 'b', 'c'],
                          {'_rule_type': 'intrange', 'max': 1}),
-                         (u'((a->%s->>%s)::int <= %s)', [u'b', u'c', 1]))
+                         (u'((a->%s->>%s)::int <= %s)',
+                          [u'b', u'c', 1]))
         self.assertEqual(FilterTree.intrange_filter(['a', 'b', 'c'],
                          {'_rule_type': 'intrange', 'max': 1, 'min': None}),
-                         (u'((a->%s->>%s)::int <= %s)', [u'b', u'c', 1]))
+                         (u'((a->%s->>%s)::int <= %s)',
+                          [u'b', u'c', 1]))
 
     def test_exclude_null_filters(self):
         """Test that filters which return None are excluded from the query string"""
@@ -159,4 +166,4 @@ class JsonBFilterTests(TestCase):
         jsonb_query = {'should_be': other_rule, 'should_not_be': int_none_rule}
         ft = FilterTree(jsonb_query, 'data')
         sql_str, sql_params = ft.sql()
-        self.assertFalse('AND' in sql_str, 'Found "AND" in query string')  # Should only be one rule.
+        self.assertFalse('AND' in sql_str, 'Found "AND" in query string')  # Should only be one


### PR DESCRIPTION
Previously, if an object was missing the field to which a range filter
is applied, that object would be excluded from the query result, even
if either the min or the max of the range query was null. Now, objects
missing the field to which the range query is applied will be included
if either the min or max of the query is null. If both the min and the
max are specified, then only objects which contain the field will be
returned.

This only applies in the case of missing fields inside related content
types. That is, if an object has "Accident Details" but is missing
"num_casualties" from "Accident Details", then it will be included in
range filters where min or max is null, e.g.

```
{"Accident Details":
  {"num_casualties": {"_rule_type": "intrange", "min": 1, "max": null}
}
```

However, if the object is missing the "Accident Details" related content
type entirely, then it will be excluded.

Closes https://github.com/WorldBank-Transport/DRIVER/issues/276
