### PR TITLE
Use 'OR's to connect pattern search

### DIFF
--- a/djsonb/lookups.py
+++ b/djsonb/lookups.py
@@ -69,20 +69,20 @@ class FilterTree:
                     sql_tuple = FilterTree.text_similarity_filter(rule[0], rule[1], True)
                     pattern_specs.append(sql_tuple)
                 else:
-                    sql_tuple = pattern_specs.append(FilterTree.text_similarity_filter(rule[0], rule[1], False))
+                    sql_tuple = FilterTree.text_similarity_filter(rule[0], rule[1], False)
                     pattern_specs.append(sql_tuple)
 
 
         rule_strings = [' AND '.join([rule[0] for rule in rule_specs]),
-                        ' OR '.join([rule[0] for rule in pattern_specs if rule is not None])]
+                        ' OR '.join([rule[0] for rule in pattern_specs])]
         if rule_strings[0] != '' and rule_strings[1] != '':
-            rule_strings = ' AND ('.join(rule_strings) + ')'
+            rule_strings = '(' + (' AND ('.join(rule_strings)) + ')' + ')'
         else:
-            rule_strings = ''.join(rule_strings)
+            rule_strings = '(' + ''.join(rule_strings) + ')'
 
         # flatten the rule_paths
         rule_paths_first = ([rule[1] for rule in rule_specs] +
-                            [rule[1] for rule in pattern_specs if rule is not None])
+                            [rule[1] for rule in pattern_specs])
         rule_paths = [item for sublist in rule_paths_first
                       for item in sublist]
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ PostgreSQL json field support for Django.
 
 setup(
     name="djsonb",
-    version="0.1.5",
+    version="0.1.6",
     url="https://github.com/azavea/djsonb",
     license="BSD",
     platforms=["OS Independent"],


### PR DESCRIPTION
It appears as though pattern searches are being strung together by ANDs, which will almost always yield no results for multiple fields. This PR aims to correct that oversight.
