### PR TITLE
Stop returning empty parens for empty filters

### DIFF
--- a/djsonb/lookups.py
+++ b/djsonb/lookups.py
@@ -77,8 +77,10 @@ class FilterTree:
                         ' OR '.join([rule[0] for rule in pattern_specs])]
         if rule_strings[0] != '' and rule_strings[1] != '':
             rule_strings = '(' + (' AND ('.join(rule_strings)) + ')' + ')'
-        else:
+        elif rule_strings[0] != '' or rule_strings[1] != '':
             rule_strings = '(' + ''.join(rule_strings) + ')'
+        else:
+            rule_strings = ''
 
         # flatten the rule_paths
         rule_paths_first = ([rule[1] for rule in rule_specs] +
@@ -110,7 +112,10 @@ class FilterTree:
 
         contains_str = ' OR '.join([abstract_contains_str] * len(all_contained))
 
-        return ('(' + contains_str + ')', contains_params)
+        if contains_str != '':
+            return ('(' + contains_str + ')', contains_params)
+        else:
+            return None
 
     @classmethod
     def multiple_containment_filter(cls, path, rule):
@@ -133,7 +138,10 @@ class FilterTree:
 
         contains_str = ' OR '.join([abstract_contains_str] * len(all_contained))
 
-        return ('(' + contains_str + ')', contains_params)
+        if contains_str != '':
+            return ('(' + contains_str + ')', contains_params)
+        else:
+            return None
 
     @classmethod
     def intrange_filter(cls, path, rule):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ PostgreSQL json field support for Django.
 
 setup(
     name="djsonb",
-    version="0.1.6",
+    version="0.1.7",
     url="https://github.com/azavea/djsonb",
     license="BSD",
     platforms=["OS Independent"],

--- a/tests/djsonb_fields/tests.py
+++ b/tests/djsonb_fields/tests.py
@@ -280,6 +280,20 @@ class JsonBFilterTests(TestCase):
         sql_str, sql_params = ft.sql()
         self.assertFalse('AND' in sql_str, 'Found "AND" in query string')  # Should only be one
 
+    def test_empty_filters(self):
+        """Test that fully-empty filters work and return all instances"""
+        JsonBModel.objects.create(data={'a': {'b': {'c': "zog", 'd': "zog"}}})
+        JsonBModel.objects.create(data={'a': {'b': {'c': "zog", 'd': 9000}}})
+        JsonBModel.objects.create(data={'a': {'b': [{'c': "zog"}, {'c': "dog"}]}})
+
+        empty_intrange = {'a': {'b': {'c': {'_rule_type': 'intrange', 'min': None, 'max': None}}}}
+        empty_containment = {'a': {'b': {'c': {'_rule_type': 'containment', 'contains': []}}}}
+        empty_mult_containment = {'a': {'b': {'c': {'_rule_type': 'containment_multiple',
+                                                    'contains': []}}}}
+        self.assertEqual(JsonBModel.objects.filter(data__jsonb=empty_intrange).count(), 3)
+        self.assertEqual(JsonBModel.objects.filter(data__jsonb=empty_containment).count(), 3)
+        self.assertEqual(JsonBModel.objects.filter(data__jsonb=empty_mult_containment).count(), 3)
+
     def test_large_search(self):
         """Test using a large json object and multiple conditions"""
         JsonBModel.objects.create(data={"Person":[{"License number":"","Name":"Rodolfo","Driver error":"Bad turning","Age":"35","Vehicle":"abc-123","Involvment":"Driver","Sex":"Male","Address":"","Injury":"Not injured","Hospital":"","_localId":"936a572d-2504-44f8-88cc-fa3c4afe82d1"},{"License number":"","Name":"Manos","Age":"45","Vehicle":"abc-123","Involvment":"Driver","Seat belt/helmet":"Not worn","Sex":"Male","Address":"","Injury":"Fatal","Hospital":"Santa Elena","_localId":"2f7163f0-af2d-48b1-a8fb-9dc0ba60dfc0"}],"Object Details":{"Description":"","Surface condition":"Dry","Main cause":"Mistake","_localId":"abc-123","Traffic control":"None","Severity":"Fatal","Collision type":"Right angle","Surface type":"Concrete"},"Vehicle":[{"Maneuver":"Reversing","Vehicle type":"Truck (Artic)","Insurance details":"","Chassis number":"","Make":"Fuso","Defect":"None","Damage":"Right","_localId":"923123","Model":"","Plate number":"","Engine number":""},{"Maneuver":"Going ahead","Direction":"North","Vehicle type":"Motorcycle","Insurance details":"","Chassis number":"","Make":"Honda","Defect":"None","Damage":"Multiple","_localId":"10583eea-864d-408d-99ff-8e57f8d687a8","Model":"","Plate number":"","Engine number":""}]})


### PR DESCRIPTION
DRIVER sends a bunch of filter parameters all the time, even if they
boil down to no actual filters being applied to the jsonb field, which
has been resulting in queries that include '... WHERE (() AND ...' and
therefore crash.
This adds checking to recognize and handle empty filters.
