### PR TITLE
Match each pattern-match word individually

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ PostgreSQL json field support for Django.
 
 setup(
     name="djsonb",
-    version="0.1.7",
+    version="0.2.0",
     url="https://github.com/azavea/djsonb",
     license="BSD",
     platforms=["OS Independent"],

--- a/tests/djsonb_fields/tests.py
+++ b/tests/djsonb_fields/tests.py
@@ -152,6 +152,15 @@ class JsonBFilterTests(TestCase):
         query1 = JsonBModel.objects.filter(data__jsonb=filt1)
         self.assertEqual(query1.count(), 1)
 
+    def test_text_similarity_split_spaces(self):
+        """Test that similarity patterns are split on spaces before filtering"""
+        JsonBModel.objects.create(data={'a': {'b': {'c': "goose meese"}}})
+        JsonBModel.objects.create(data={'a': {'b': {'c': "moose geese"}}})
+        filt1 = {'a': {'b': {'c': {'_rule_type': 'containment',
+                                   'pattern': 'moose goose'}}}}
+        query1 = JsonBModel.objects.filter(data__jsonb=filt1)
+        self.assertEqual(query1.count(), 2)
+
     def test_text_similarity_multiple(self):
         JsonBModel.objects.create(data={'a': {'b': [{'c': "beegels"}, {'c': "beagels"}]}})
         JsonBModel.objects.create(data={'a': {'b': [{'c': "beegles"}]}})


### PR DESCRIPTION
Previously, the text-search functionality would treat the whole text input as requiring an exact match, which was seldom useful. This now splits the text input on spaces before generating filters, which allows records that contain _any_ of the words to match.

The disadvantage to this, however, is that it makes doing very precise searches difficult, e.g. where a long, exact phrase to search for is known in advance and can be copy-pasted in. If we find that this is a problematic limitation, we may want to investigate something more full-featured, such as ElasticSearch.
